### PR TITLE
makes dist tar file not explode into ./ (fixes #3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ WITH_LAPACK = 1
 FORCE_32BIT = 
 FORCE_DYNAMIC = 
 FORCE_FLOAT = 
+DIST_NAME = gemma-0.95alpha
 
 # --------------------------------------------------------------------
 # Edit below this line with caution
@@ -106,6 +107,14 @@ $(OBJS) : $(HDR)
 
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ ${SRC_DIR}/*_float.*
+
+DIST_COMMON = COPYING.txt README.txt Makefile
+DIST_SUBDIRS = src doc example bin
+
 tar:
-	tar cvzf gemma-0.93.tar.gz COPYING.txt  README.txt  Makefile  src  doc  example  bin
+	mkdir -p ./$(DIST_NAME)
+	cp $(DIST_COMMON) ./$(DIST_NAME)/
+	cp -r $(DIST_SUBDIRS) ./$(DIST_NAME)/
+	tar cvzf $(DIST_NAME).tar.gz ./$(DIST_NAME)/
+	rm -r ./$(DIST_NAME)
 


### PR DESCRIPTION
Modifies the 'tar' Makefile target by copying the distribution files to a temporary directory (named by the Make variable DIST_NAME) and then tars up that directory such that the files will expand into a subdirectory (in this case named 'gemma-0.95alpha').
