### PR TITLE
Fixes dynamic compilation (fixes #9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ CPP = g++
 
 CPPFLAGS = -Wall -O3
 
+ifdef FORCE_DYNAMIC
+LIBS = -lgsl -lgslcblas -lblas -pthread -lz
+else
 LIBS = -lgsl -lgslcblas -pthread -lz
+endif
 
 OUTPUT = $(BIN_DIR)/gemma
 


### PR DESCRIPTION
Fixes dynamic compilation on systems where -lblas is required
for symbols such as `dgemm_`
