### PR TITLE
Compiler warnings are optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.tar.gz
 src/Eigen
 example/output
+test/output
+./output
 doc/manual.aux
 doc/manual.bbl
 doc/manual.blg

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ Install listed dependencies and run
 if you get an Eigen error you may need to override the include
 path. E.g. on GNU Guix with shared libs this may work
 
-    make EIGEN_INCLUDE_PATH=~/.guix-profile/include/eigen3 FORCE_DYNAMIC=1
+    make EIGEN_INCLUDE_PATH=~/.guix-profile/include/eigen3 FORCE_DYNAMIC=1 WITH_OPENBLAS=1
 
 to run GEMMA tests
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,3 +48,7 @@ if you get an Eigen error you may need to override the include
 path. E.g. on GNU Guix with shared libs this may work
 
     make EIGEN_INCLUDE_PATH=~/.guix-profile/include/eigen3 FORCE_DYNAMIC=1
+
+to run GEMMA tests
+
+    make check

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ $(OBJS) : $(HDR)
 	$(CPP) $(CPPFLAGS) $(HEADERS) -c $*.cpp -o $*.o
 .SUFFIXES : .cpp .c .o $(SUFFIXES)
 
+check:
+	./run_tests.sh
 
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(OBJS) : $(HDR)
 .SUFFIXES : .cpp .c .o $(SUFFIXES)
 
 check: all
-	./run_tests.sh
+	cd test && ./test_suite.sh
 
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRC_DIR  = ./src
 
 CPP = g++
 
-CPPFLAGS = -O3 -std=gnu++11 -isystem$(EIGEN_INCLUDE_PATH)
+CPPFLAGS = -O3 -std=gnu++11 -isystem/$(EIGEN_INCLUDE_PATH)
 
 ifdef SHOW_COMPILER_WARNINGS
   CPPFLAGS += -Wall

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ $(OBJS) : $(HDR)
 .SUFFIXES : .cpp .c .o $(SUFFIXES)
 
 check: all
-	cd test && ./test_suite.sh | grep -q 'success rate: 100%'
+	cd test && ./test_suite.sh | tee ../test.log
+	grep -q 'success rate: 100%' test.log
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ $(OUTPUT)
 

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,7 @@ $(OBJS) : $(HDR)
 .SUFFIXES : .cpp .c .o $(SUFFIXES)
 
 check: all
-	cd test && ./test_suite.sh
-
+	cd test && ./test_suite.sh | grep -q 'success rate: 100%'
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ $(OUTPUT)
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRC_DIR  = ./src
 
 CPP = g++
 
-CPPFLAGS = -O3 -std=gnu++11 -I$(EIGEN_INCLUDE_PATH)
+CPPFLAGS = -O3 -std=gnu++11 -isystem$(EIGEN_INCLUDE_PATH)
 
 ifdef SHOW_COMPILER_WARNINGS
   CPPFLAGS += -Wall

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SRC_DIR  = ./src
 
 CPP = g++
 
-CPPFLAGS = -Wall -Weffc++ -O3 -std=gnu++11 -I$(EIGEN_INCLUDE_PATH)
+CPPFLAGS = -Wall -O3 -std=gnu++11 -I$(EIGEN_INCLUDE_PATH)
 
 ifdef FORCE_DYNAMIC
 LIBS = -lgsl -lgslcblas -pthread -lz
@@ -104,6 +104,7 @@ $(OBJS) : $(HDR)
 check: all
 	cd test && ./test_suite.sh | tee ../test.log
 	grep -q 'success rate: 100%' test.log
+
 clean:
 	rm -rf ${SRC_DIR}/*.o ${SRC_DIR}/*~ *~ $(OUTPUT)
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 # Set this variable to either LNX or MAC
 SYS = LNX
 # Leave blank after "=" to disable; put "= 1" to enable
+SHOW_COMPILER_WARNINGS   =
 WITH_LAPACK     = 1
 WITH_OPENBLAS   =
 NO_INTEL_COMPAT =
@@ -29,12 +30,16 @@ SRC_DIR  = ./src
 
 CPP = g++
 
-CPPFLAGS = -Wall -O3 -std=gnu++11 -I$(EIGEN_INCLUDE_PATH)
+CPPFLAGS = -O3 -std=gnu++11 -I$(EIGEN_INCLUDE_PATH)
+
+ifdef SHOW_COMPILER_WARNINGS
+  CPPFLAGS += -Wall
+endif
 
 ifdef FORCE_DYNAMIC
-LIBS = -lgsl -lgslcblas -pthread -lz
+  LIBS = -lgsl -lgslcblas -pthread -lz
 else
-LIBS = -lgsl -lgslcblas -pthread -lz
+  LIBS = -lgsl -lgslcblas -pthread -lz
 endif
 
 OUTPUT = $(BIN_DIR)/gemma

--- a/example/demo.txt
+++ b/example/demo.txt
@@ -67,17 +67,17 @@ chr	rs	ps	n_miss	allele1	allele0	af	beta_1	beta_2	Vbeta_1_1	Vbeta_1_2	Vbeta_2_2	
 1	rs13475700	4098402	0	A	C	0.128	-6.727883e-02	1.685363e-01	5.597160e-03	-1.366799e-04	7.574216e-03	1.060482e-01
 
 # The log file also contains Vg and Ve estimates and their standard errors
-## REMLE estimate for Vg in the null model: 
-1.39398	
--0.226714	2.08168	
-## se(Vg): 
-0.156661	
-0.136319	0.235858	
-## REMLE estimate for Ve in the null model: 
-0.348882	
-0.0490525	0.414433	
-## se(Ve): 
-0.0206226	
+## REMLE estimate for Vg in the null model:
+1.39398
+-0.226714	2.08168
+## se(Vg):
+0.156661
+0.136319	0.235858
+## REMLE estimate for Ve in the null model:
+0.348882
+0.0490525	0.414433
+## se(Ve):
+0.0206226
 0.0166233	0.0266869
 
 # Since there are individuals with partially missing phenotypes, one can impute these missing values before association tests

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# download shunit2 in order to run tests:
+# curl -L "https://dl.dropboxusercontent.com/u/7916095/shunit2-2.0.3.tgz" | tar zx --overwrite
+
+cd test
+./test_suite.sh | tee /dev/stderr | grep -q 'success rate: 100%'

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -11,6 +11,7 @@ testCenteredRelatednessMatrixK() {
     assertEquals "3763600" `wc -w < output/mouse_hs1940.cXX.txt`
     # assertEquals "15f680c" `md5sum < output/mouse_hs1940.cXX.txt | head -c 7`
     assertEquals "0.335" `head -c 5 output/mouse_hs1940.cXX.txt`
+    # FIXME: The following test fails in the Guix build system (https://github.com/xiangzhou/GEMMA/issues/55)
     assertEquals "29.691" `awk '{s+=substr($1,0,6)}END{print s}' output/mouse_hs1940.cXX.txt`
 }
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -11,6 +11,23 @@ testCenteredRelatednessMatrixK() {
     assertEquals "29.691" `awk '{s+=substr($1,0,6)}END{print s}' output/mouse_hs1940.cXX.txt`
 }
 
+testUnivariateLinearMixedModel() {
+    $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt -n 1 \
+           -a ../example/mouse_hs1940.anno.txt -k ./output/mouse_hs1940.cXX.txt -lmm \
+           -o mouse_hs1940_CD8_lmm
+    assertEquals "118459" `wc -w < output/mouse_hs1940_CD8_lmm.assoc.txt`
+    assertEquals "92047" `awk '{s+=substr($1,0,6)}END{print s}' output/mouse_hs1940_CD8_lmm.assoc.txt`
+}
+
+testMultivariateLinearMixedModel() {
+    $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt \
+           -n 1 6 -a ../example/mouse_hs1940.anno.txt -k ./output/mouse_hs1940.cXX.txt \
+           -lmm -o mouse_hs1940_CD8MCH_lmm
+    outfn=output/mouse_hs1940_CD8MCH_lmm.assoc.txt
+    assertEquals "139867" `wc -w < $outfn`
+    assertEquals "92079" `awk '{s+=substr($1,0,6)}END{print s}' $outfn`
+}
+
 shunit2=`which shunit2`
 if [ -x "$shunit2" ]; then
     . $shunit2

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+gemma=../bin/gemma
+
+testCenteredRelatednessMatrix() {
+    $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt \
+                 -a ../example/mouse_hs1940.anno.txt -gk -o mouse_hs1940
+    assertEquals "3763600" `wc -w < output/mouse_hs1940.cXX.txt`
+}
+
+shunit2=`which shunit2`
+if [ -x "$shunit2" ]; then
+    . $shunit2
+else
+    # try to run the locally installed shunit2
+    . ../shunit2-2.0.3/src/shell/shunit2
+fi

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -5,6 +5,9 @@ gemma=../bin/gemma
 testCenteredRelatednessMatrixK() {
     $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt \
            -a ../example/mouse_hs1940.anno.txt -gk -o mouse_hs1940
+    assertEquals 0 $?
+    grep "total computation time" < output/mouse_hs1940.log.txt
+    assertEquals 0 $?
     assertEquals "3763600" `wc -w < output/mouse_hs1940.cXX.txt`
     # assertEquals "15f680c" `md5sum < output/mouse_hs1940.cXX.txt | head -c 7`
     assertEquals "0.335" `head -c 5 output/mouse_hs1940.cXX.txt`
@@ -15,6 +18,9 @@ testUnivariateLinearMixedModel() {
     $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt -n 1 \
            -a ../example/mouse_hs1940.anno.txt -k ./output/mouse_hs1940.cXX.txt -lmm \
            -o mouse_hs1940_CD8_lmm
+    assertEquals 0 $?
+    grep "total computation time" < output/mouse_hs1940_CD8_lmm.log.txt
+    assertEquals 0 $?
     assertEquals "118459" `wc -w < output/mouse_hs1940_CD8_lmm.assoc.txt`
     assertEquals "92047" `awk '{s+=substr($1,0,6)}END{print s}' output/mouse_hs1940_CD8_lmm.assoc.txt`
 }
@@ -23,6 +29,10 @@ testMultivariateLinearMixedModel() {
     $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt \
            -n 1 6 -a ../example/mouse_hs1940.anno.txt -k ./output/mouse_hs1940.cXX.txt \
            -lmm -o mouse_hs1940_CD8MCH_lmm
+    assertEquals 0 $?
+    grep "total computation time" < output/mouse_hs1940_CD8MCH_lmm.log.txt
+    assertEquals 0 $?
+
     outfn=output/mouse_hs1940_CD8MCH_lmm.assoc.txt
     assertEquals "139867" `wc -w < $outfn`
     assertEquals "92079" `awk '{s+=substr($1,0,6)}END{print s}' $outfn`

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -2,10 +2,13 @@
 
 gemma=../bin/gemma
 
-testCenteredRelatednessMatrix() {
+testCenteredRelatednessMatrixK() {
     $gemma -g ../example/mouse_hs1940.geno.txt.gz -p ../example/mouse_hs1940.pheno.txt \
-                 -a ../example/mouse_hs1940.anno.txt -gk -o mouse_hs1940
+           -a ../example/mouse_hs1940.anno.txt -gk -o mouse_hs1940
     assertEquals "3763600" `wc -w < output/mouse_hs1940.cXX.txt`
+    # assertEquals "15f680c" `md5sum < output/mouse_hs1940.cXX.txt | head -c 7`
+    assertEquals "0.335" `head -c 5 output/mouse_hs1940.cXX.txt`
+    assertEquals "29.691" `awk '{s+=substr($1,0,6)}END{print s}' output/mouse_hs1940.cXX.txt`
 }
 
 shunit2=`which shunit2`


### PR DESCRIPTION
This creates a silent build by default on gcc 7.1.0.

Note the unit testing patches are included as I am continuing on that work.