### PR TITLE
Fixes matrix checks - looking saner now

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -19,12 +19,27 @@
 #include "mathfunc.h"
 
 // Helper function called by macro validate_K(K, check)
-void do_validate_K(const gsl_matrix *K, bool do_check, const char *__file, int __line) {
+void do_validate_K(const gsl_matrix *K, bool do_check, bool strict, const char *__file, int __line) {
   if (do_check) {
-    debug_msg("Validating K");
-    if (!checkMatrixEigen(K)) warning_at_msg(__file,__line,"K has small or negative eigenvalues!");
-    if (!isMatrixIllConditioned(K)) warning_at_msg(__file,__line,"K is ill conditioned!")    if (!isMatrixSymmetric(K)) fail_at_msg(__file,__line,"K is not symmetric!" );
-    if (!isMatrixPositiveDefinite(K)) fail_at_msg(__file,__line,"K is not positive definite!");
-;
+    // debug_msg("Validating K");
+    auto eigenvalues = getEigenValues(K);
+    uint count_small;
+    if (count_small = count_small_values(eigenvalues,EIGEN_MINVALUE)>1) {
+      std::string msg = "K has ";
+      msg += std::to_string(count_small);
+      msg += " eigenvalues close to zero";
+      warning_at_msg(__file,__line,msg);
+    }
+    if (!isMatrixIllConditioned(eigenvalues))
+      warning_at_msg(__file,__line,"K is ill conditioned!");
+    if (!isMatrixSymmetric(K))
+      fail_at_msg(strict,__file,__line,"K is not symmetric!" );
+    bool negative_values;
+    if (negative_values = has_negative_values_but_one(eigenvalues)) {
+      warning_at_msg(__file,__line,"K has more than one negative eigenvalues!");
+    }
+    if (count_small>=0 && negative_values && !isMatrixPositiveDefinite(K))
+      fail_at_msg(strict,__file,__line,"K is not positive definite!");
+    gsl_vector_free(eigenvalues);
   }
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -12,16 +12,21 @@ void gemma_gsl_error_handler (const char * reason,
 
 
 // Validation routines
-void do_validate_K(const gsl_matrix *K, bool do_check, const char *__file, int __line);
+void do_validate_K(const gsl_matrix *K, bool do_check, bool strict, const char *__file, int __line);
 
 #define ROUND(f) round(f * 10000.)/10000
-#define validate_K(K,check) do_validate_K(K,check,__FILE__,__LINE__)
+#define validate_K(K,check,strict) do_validate_K(K,check,strict,__FILE__,__LINE__)
 
 #define warning_at_msg(__file,__line,msg) cerr << "**** WARNING: " << msg << " in " << __file << " at line " << __line << endl;
 
-inline void fail_at_msg(const char *__file, int __line, const char *msg) {
-  std::cerr << "**** FAIL: " << msg << " in " << __file << " at line " << __line << std::endl;
-  exit(1);
+inline void fail_at_msg(bool strict, const char *__file, int __line, const char *msg) {
+  if (strict)
+    std::cerr << "**** STRICT FAIL: ";
+  else
+    std::cerr << "**** WARNING: ";
+  std::cerr << msg << " in " << __file << " at line " << __line << std::endl;
+  if (strict)
+    exit(1);
 }
 #if defined NDEBUG
 

--- a/src/lapack.cpp
+++ b/src/lapack.cpp
@@ -446,15 +446,25 @@ double EigenDecomp_Zeroed(gsl_matrix *G, gsl_matrix *U, gsl_vector *eval,
                           const size_t flag_largematrix) {
   EigenDecomp(G,U,eval,flag_largematrix);
   auto d = 0.0;
+  int count_zero_eigenvalues = 0;
   int count_negative_eigenvalues = 0;
   for (size_t i = 0; i < eval->size; i++) {
     if (std::abs(gsl_vector_get(eval, i)) < EIGEN_MINVALUE)
       gsl_vector_set(eval, i, 0.0);
-    if (gsl_vector_get(eval,i) < 0.0)
+    // checks
+    if (gsl_vector_get(eval,i) == 0.0)
+      count_zero_eigenvalues += 1;
+    if (gsl_vector_get(eval,i) < 0.0) // count smaller than -EIGEN_MINVALUE
       count_negative_eigenvalues += 1;
     d += gsl_vector_get(eval, i);
   }
   d /= (double)eval->size;
+  if (count_zero_eigenvalues > 1) {
+    std::string msg = "Matrix G has ";
+    msg += std::to_string(count_zero_eigenvalues);
+    msg += " eigenvalues close to zero";
+    warning_msg(msg);
+  }
   if (count_negative_eigenvalues > 0) {
     warning_msg("Matrix G has more than one negative eigenvalues!");
   }

--- a/src/lapack.cpp
+++ b/src/lapack.cpp
@@ -23,8 +23,12 @@
 #include <iostream>
 #include <vector>
 
+#include "debug.h"
+#include "mathfunc.h"
+
 using namespace std;
 
+/*
 extern "C" void sgemm_(char *TRANSA, char *TRANSB, int *M, int *N, int *K,
                        float *ALPHA, float *A, int *LDA, float *B, int *LDB,
                        float *BETA, float *C, int *LDC);
@@ -39,6 +43,7 @@ extern "C" void ssyevr_(char *JOBZ, char *RANGE, char *UPLO, int *N, float *A,
                         int *ISUPPZ, float *WORK, int *LWORK, int *IWORK,
                         int *LIWORK, int *INFO);
 extern "C" double sdot_(int *N, float *DX, int *INCX, float *DY, int *INCY);
+*/
 
 extern "C" void dgemm_(char *TRANSA, char *TRANSB, int *M, int *N, int *K,
                        double *ALPHA, double *A, int *LDA, double *B, int *LDB,
@@ -55,6 +60,7 @@ extern "C" void dsyevr_(char *JOBZ, char *RANGE, char *UPLO, int *N, double *A,
                         int *LIWORK, int *INFO);
 extern "C" double ddot_(int *N, double *DX, int *INCX, double *DY, int *INCY);
 
+/*
 // Cholesky decomposition, A is destroyed.
 void lapack_float_cholesky_decomp(gsl_matrix_float *A) {
   int N = A->size1, LDA = A->size1, INFO;
@@ -75,6 +81,7 @@ void lapack_float_cholesky_decomp(gsl_matrix_float *A) {
 
   return;
 }
+*/
 
 // Cholesky decomposition, A is destroyed.
 void lapack_cholesky_decomp(gsl_matrix *A) {
@@ -97,6 +104,7 @@ void lapack_cholesky_decomp(gsl_matrix *A) {
   return;
 }
 
+/*
 // Cholesky solve, A is decomposed.
 void lapack_float_cholesky_solve(gsl_matrix_float *A, const gsl_vector_float *b,
                                  gsl_vector_float *x) {
@@ -118,6 +126,7 @@ void lapack_float_cholesky_solve(gsl_matrix_float *A, const gsl_vector_float *b,
 
   return;
 }
+*/
 
 // Cholesky solve, A is decomposed.
 void lapack_cholesky_solve(gsl_matrix *A, const gsl_vector *b, gsl_vector *x) {
@@ -140,6 +149,7 @@ void lapack_cholesky_solve(gsl_matrix *A, const gsl_vector *b, gsl_vector *x) {
   return;
 }
 
+/*
 void lapack_sgemm(char *TransA, char *TransB, float alpha,
                   const gsl_matrix_float *A, const gsl_matrix_float *B,
                   float beta, gsl_matrix_float *C) {
@@ -192,6 +202,7 @@ void lapack_sgemm(char *TransA, char *TransB, float alpha,
   gsl_matrix_float_free(C_t);
   return;
 }
+*/
 
 void lapack_dgemm(char *TransA, char *TransB, double alpha, const gsl_matrix *A,
                   const gsl_matrix *B, double beta, gsl_matrix *C) {
@@ -246,6 +257,7 @@ void lapack_dgemm(char *TransA, char *TransB, double alpha, const gsl_matrix *A,
   return;
 }
 
+/*
 // Eigen value decomposition, matrix A is destroyed, float seems to
 // have problem with large matrices (in mac).
 void lapack_float_eigen_symmv(gsl_matrix_float *A, gsl_vector_float *eval,
@@ -328,7 +340,10 @@ void lapack_float_eigen_symmv(gsl_matrix_float *A, gsl_vector_float *eval,
   return;
 }
 
-// Eigenvalue decomposition, matrix A is destroyed.
+*/
+
+// Eigenvalue decomposition, matrix A is destroyed. Returns eigenvalues in
+// 'eval'. Also returns matrix 'evec' (U).
 void lapack_eigen_symmv(gsl_matrix *A, gsl_vector *eval, gsl_matrix *evec,
                         const size_t flag_largematrix) {
   if (flag_largematrix == 1) {
@@ -409,21 +424,45 @@ void lapack_eigen_symmv(gsl_matrix *A, gsl_vector *eval, gsl_matrix *evec,
   return;
 }
 
-// DO NOT set eigenvalues to be positive.
+// Does NOT set eigenvalues to be positive. G gets destroyed. Returns
+// eigen trace and values in U and eval (eigenvalues).
 double EigenDecomp(gsl_matrix *G, gsl_matrix *U, gsl_vector *eval,
                    const size_t flag_largematrix) {
   lapack_eigen_symmv(G, eval, U, flag_largematrix);
 
   // Calculate track_G=mean(diag(G)).
   double d = 0.0;
-  for (size_t i = 0; i < eval->size; ++i) {
+  for (size_t i = 0; i < eval->size; ++i)
     d += gsl_vector_get(eval, i);
-  }
+
   d /= (double)eval->size;
 
   return d;
 }
 
+// Same as EigenDecomp but zeroes eigenvalues close to zero. When
+// negative eigenvalues remain a warning is issued.
+double EigenDecomp_Zeroed(gsl_matrix *G, gsl_matrix *U, gsl_vector *eval,
+                          const size_t flag_largematrix) {
+  EigenDecomp(G,U,eval,flag_largematrix);
+  auto d = 0.0;
+  int count_negative_eigenvalues = 0;
+  for (size_t i = 0; i < eval->size; i++) {
+    if (std::abs(gsl_vector_get(eval, i)) < EIGEN_MINVALUE)
+      gsl_vector_set(eval, i, 0.0);
+    if (gsl_vector_get(eval,i) < 0.0)
+      count_negative_eigenvalues += 1;
+    d += gsl_vector_get(eval, i);
+  }
+  d /= (double)eval->size;
+  if (count_negative_eigenvalues > 0) {
+    warning_msg("Matrix G has more than one negative eigenvalues!");
+  }
+
+  return d;
+}
+
+/*
 // DO NOT set eigen values to be positive.
 double EigenDecomp(gsl_matrix_float *G, gsl_matrix_float *U,
                    gsl_vector_float *eval, const size_t flag_largematrix) {
@@ -438,6 +477,7 @@ double EigenDecomp(gsl_matrix_float *G, gsl_matrix_float *U,
 
   return d;
 }
+*/
 
 double CholeskySolve(gsl_matrix *Omega, gsl_vector *Xty, gsl_vector *OiXty) {
   double logdet_O = 0.0;
@@ -452,6 +492,7 @@ double CholeskySolve(gsl_matrix *Omega, gsl_vector *Xty, gsl_vector *OiXty) {
   return logdet_O;
 }
 
+/*
 double CholeskySolve(gsl_matrix_float *Omega, gsl_vector_float *Xty,
                      gsl_vector_float *OiXty) {
   double logdet_O = 0.0;
@@ -465,6 +506,7 @@ double CholeskySolve(gsl_matrix_float *Omega, gsl_vector_float *Xty,
 
   return logdet_O;
 }
+*/
 
 // LU decomposition.
 void LUDecomp(gsl_matrix *LU, gsl_permutation *p, int *signum) {
@@ -472,6 +514,7 @@ void LUDecomp(gsl_matrix *LU, gsl_permutation *p, int *signum) {
   return;
 }
 
+/*
 void LUDecomp(gsl_matrix_float *LU, gsl_permutation *p, int *signum) {
   gsl_matrix *LU_double = gsl_matrix_alloc(LU->size1, LU->size2);
 
@@ -496,6 +539,7 @@ void LUDecomp(gsl_matrix_float *LU, gsl_permutation *p, int *signum) {
   gsl_matrix_free(LU_double);
   return;
 }
+*/
 
 // LU invert.
 void LUInvert(const gsl_matrix *LU, const gsl_permutation *p,
@@ -504,6 +548,7 @@ void LUInvert(const gsl_matrix *LU, const gsl_permutation *p,
   return;
 }
 
+/*
 void LUInvert(const gsl_matrix_float *LU, const gsl_permutation *p,
               gsl_matrix_float *inverse) {
   gsl_matrix *LU_double = gsl_matrix_alloc(LU->size1, LU->size2);
@@ -532,6 +577,8 @@ void LUInvert(const gsl_matrix_float *LU, const gsl_permutation *p,
   return;
 }
 
+*/
+
 // LU lndet.
 double LULndet(gsl_matrix *LU) {
   double d;
@@ -539,6 +586,7 @@ double LULndet(gsl_matrix *LU) {
   return d;
 }
 
+/*
 double LULndet(gsl_matrix_float *LU) {
   gsl_matrix *LU_double = gsl_matrix_alloc(LU->size1, LU->size2);
   double d;
@@ -557,6 +605,7 @@ double LULndet(gsl_matrix_float *LU) {
   gsl_matrix_free(LU_double);
   return d;
 }
+*/
 
 // LU solve.
 void LUSolve(const gsl_matrix *LU, const gsl_permutation *p,
@@ -565,6 +614,7 @@ void LUSolve(const gsl_matrix *LU, const gsl_permutation *p,
   return;
 }
 
+/*
 void LUSolve(const gsl_matrix_float *LU, const gsl_permutation *p,
              const gsl_vector_float *b, gsl_vector_float *x) {
   gsl_matrix *LU_double = gsl_matrix_alloc(LU->size1, LU->size2);
@@ -600,7 +650,7 @@ void LUSolve(const gsl_matrix_float *LU, const gsl_permutation *p,
   gsl_vector_free(x_double);
   return;
 }
-
+*/
 bool lapack_ddot(vector<double> &x, vector<double> &y, double &v) {
   bool flag = false;
   int incx = 1;
@@ -614,6 +664,7 @@ bool lapack_ddot(vector<double> &x, vector<double> &y, double &v) {
   return flag;
 }
 
+/*
 bool lapack_sdot(vector<float> &x, vector<float> &y, double &v) {
   bool flag = false;
   int incx = 1;
@@ -626,3 +677,4 @@ bool lapack_sdot(vector<float> &x, vector<float> &y, double &v) {
 
   return flag;
 }
+*/

--- a/src/lapack.h
+++ b/src/lapack.h
@@ -41,6 +41,8 @@ void lapack_eigen_symmv(gsl_matrix *A, gsl_vector *eval, gsl_matrix *evec,
 
 double EigenDecomp(gsl_matrix *G, gsl_matrix *U, gsl_vector *eval,
                    const size_t flag_largematrix);
+double EigenDecomp_Zeroed(gsl_matrix *G, gsl_matrix *U, gsl_vector *eval,
+                   const size_t flag_largematrix);
 double EigenDecomp(gsl_matrix_float *G, gsl_matrix_float *U,
                    gsl_vector_float *eval, const size_t flag_largematrix);
 

--- a/src/mathfunc.h
+++ b/src/mathfunc.h
@@ -23,6 +23,9 @@
 #include "gsl/gsl_matrix.h"
 #include "gsl/gsl_vector.h"
 
+#define CONDITIONED_MAXRATIO 2e+6 // based on http://mathworld.wolfram.com/ConditionNumber.html
+#define EIGEN_MINVALUE 1e-10
+
 using namespace std;
 using namespace Eigen;
 
@@ -34,10 +37,12 @@ void CenterMatrix(gsl_matrix *G, const gsl_vector *w);
 void CenterMatrix(gsl_matrix *G, const gsl_matrix *W);
 void StandardizeMatrix(gsl_matrix *G);
 double ScaleMatrix(gsl_matrix *G);
+bool has_negative_values_but_one(const gsl_vector *v);
+uint count_small_values(const gsl_vector *v, double min);
 bool isMatrixPositiveDefinite(const gsl_matrix *G);
-bool isMatrixIllConditioned(const gsl_matrix *G, double max_ratio=4.0);
+bool isMatrixIllConditioned(const gsl_vector *eigenvalues, double max_ratio=CONDITIONED_MAXRATIO);
 bool isMatrixSymmetric(const gsl_matrix *G);
-bool checkMatrixEigen(const gsl_matrix *G, double min=1e-5);
+gsl_vector *getEigenValues(const gsl_matrix *G);
 double SumVector(const gsl_vector *v);
 double CenterVector(gsl_vector *y);
 void CenterVector(gsl_vector *y, const gsl_matrix *W);

--- a/src/mvlmm.cpp
+++ b/src/mvlmm.cpp
@@ -257,14 +257,7 @@ double EigenProc(const gsl_matrix *V_g, const gsl_matrix *V_e, gsl_vector *D_l,
   gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, V_e_hi, VgVehi, 0.0, Lambda);
 
   // Eigen decomposition of Lambda.
-  EigenDecomp(Lambda, U_l, D_l, 0);
-
-  for (size_t i = 0; i < d_size; i++) {
-    d = gsl_vector_get(D_l, i);
-    if (d < 0) {
-      gsl_vector_set(D_l, i, 0);
-    }
-  }
+  EigenDecomp_Zeroed(Lambda, U_l, D_l, 0);
 
   // Calculate UltVeh and UltVehi.
   gsl_blas_dgemm(CblasTrans, CblasNoTrans, 1.0, U_l, V_e_h, 0.0, UltVeh);

--- a/src/param.cpp
+++ b/src/param.cpp
@@ -2022,12 +2022,12 @@ void PARAM::CheckCvt() {
     }
   }
 
-  // Add an intecept term if needed.
+  // Add an intercept term if needed.
   if (n_cvt == set_remove.size()) {
     indicator_cvt.clear();
     n_cvt = 1;
   } else if (flag_ipt == 0) {
-    cout << "no intecept term is found in the cvt file. "
+    cout << "no intercept term is found in the cvt file. "
          << "a column of 1s is added." << endl;
     for (vector<int>::size_type i = 0; i < indicator_idv.size(); ++i) {
       if (indicator_idv[i] == 0 || indicator_cvt[i] == 0) {

--- a/src/param.h
+++ b/src/param.h
@@ -112,7 +112,8 @@ public:
 class PARAM {
 public:
   // IO-related parameters
-  bool mode_check = true;
+  bool mode_check = true;   // run data checks (slower)
+  bool mode_strict = false; // exit on some data checks
   bool mode_silence;
   bool mode_debug = false;
   uint issue; // enable tests for issue on github tracker

--- a/test/src/unittests-math.cpp
+++ b/test/src/unittests-math.cpp
@@ -16,21 +16,21 @@ TEST_CASE( "Math functions", "[math]" ) {
   copy(data, data+9, m->data);
   REQUIRE( isMatrixPositiveDefinite(m) );
   REQUIRE( isMatrixSymmetric(m) );
-  REQUIRE( checkMatrixEigen(m,0.001) );
+  // REQUIRE( checkMatrixEigen(m,0.001) );
 
   double data1[] = {1.0,0,0,
                     0,3.0,0,
                     0,0,2.0};
   copy(data1, data1+9, m->data);
   REQUIRE( isMatrixPositiveDefinite(m) );
-  REQUIRE( checkMatrixEigen(m) );
+  // REQUIRE( checkMatrixEigen(m) );
 
   double data2[] = {1,1,1,
                     1,1,1,
                     1,1,0.5};
   copy(data2, data2+9, m->data);
   REQUIRE( !isMatrixPositiveDefinite(m));
-  REQUIRE( !checkMatrixEigen(m) );
+  // REQUIRE( !checkMatrixEigen(m) );
 
   double data3[] = {1.0,  0,  0,
                     3.0,3.0,  0,
@@ -38,7 +38,7 @@ TEST_CASE( "Math functions", "[math]" ) {
   copy(data3, data3+9, m->data);
   REQUIRE( !isMatrixPositiveDefinite(m) );
   REQUIRE( !isMatrixSymmetric(m) );
-  REQUIRE( !checkMatrixEigen(m) );
+  // REQUIRE( checkMatrixEigen(m) );
 
   // ---- NaN checks
   vector<double> v = {1.0, 2.0};

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -8,9 +8,10 @@ testCenteredRelatednessMatrixKFullLOCO1() {
            -p ../example/mouse_hs1940.pheno.txt \
            -a ../example/mouse_hs1940.anno.txt \
            -loco 1 -gk -debug -o $outn
-    assertEquals 1 $?
-    # assertEquals "1940" `wc -l < $outfn`
-    # assertEquals "2246.57" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    outfn=output/$outn.cXX.txt
+    assertEquals "1940" `wc -l < $outfn`
+    assertEquals "2246.57" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 testUnivariateLinearMixedModelFullLOCO1() {
@@ -24,26 +25,24 @@ testUnivariateLinearMixedModelFullLOCO1() {
 	   -lmm \
 	   -debug \
            -o $outn
-    assertEquals 1 $?
-    # grep "total computation time" < output/$outn.log.txt
-    # assertEquals 0 $?
-    # outfn=output/$outn.assoc.txt
-    # assertEquals "951" `wc -l < $outfn`
-    # assertEquals "267509369.79" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    grep "total computation time" < output/$outn.log.txt
+    assertEquals 0 $?
+    outfn=output/$outn.assoc.txt
+    assertEquals "951" `wc -l < $outfn`
+    assertEquals "267509369.79" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 testCenteredRelatednessMatrixK() {
     $gemma -g ../example/mouse_hs1940.geno.txt.gz \
            -p ../example/mouse_hs1940.pheno.txt \
            -gk -o mouse_hs1940
-    assertEquals 1 $?
-    # grep "total computation time" < output/mouse_hs1940.log.txt
-    # assertEquals 1 $?
-    # outfn=output/mouse_hs1940.cXX.txt
-    # assertEquals "1940" `wc -l < $outfn`
-    # assertEquals "3763600" `wc -w < $outfn`
-    # assertEquals "0.335" `head -c 5 $outfn`
-    # assertEquals "1119.64" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    outfn=output/mouse_hs1940.cXX.txt
+    assertEquals "1940" `wc -l < $outfn`
+    assertEquals "3763600" `wc -w < $outfn`
+    assertEquals "0.335" `head -c 5 $outfn`
+    assertEquals "1119.64" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 testUnivariateLinearMixedModel() {
@@ -54,12 +53,12 @@ testUnivariateLinearMixedModel() {
            -k ./output/mouse_hs1940.cXX.txt \
            -lmm \
            -o mouse_hs1940_CD8_lmm
-    assertEquals 1 $?
-    # grep "total computation time" < output/mouse_hs1940_CD8_lmm.log.txt
-    # assertEquals 0 $?
-    # outfn=output/mouse_hs1940_CD8_lmm.assoc.txt
-    # assertEquals "118459" `wc -w < $outfn`
-    # assertEquals "4038557453.62" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    grep "total computation time" < output/mouse_hs1940_CD8_lmm.log.txt
+    assertEquals 0 $?
+    outfn=output/mouse_hs1940_CD8_lmm.assoc.txt
+    assertEquals "118459" `wc -w < $outfn`
+    assertEquals "4038557453.62" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 testMultivariateLinearMixedModel() {
@@ -69,11 +68,11 @@ testMultivariateLinearMixedModel() {
            -a ../example/mouse_hs1940.anno.txt \
            -k ./output/mouse_hs1940.cXX.txt \
            -lmm -o mouse_hs1940_CD8MCH_lmm
-    assertEquals 1 $?
+    assertEquals 0 $?
 
-    # outfn=output/mouse_hs1940_CD8MCH_lmm.assoc.txt
-    # assertEquals "139867" `wc -w < $outfn`
-    # assertEquals "4029037056.54" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    outfn=output/mouse_hs1940_CD8MCH_lmm.assoc.txt
+    assertEquals "139867" `wc -w < $outfn`
+    assertEquals "4029037056.54" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 testPlinkStandardRelatednessMatrixK() {
@@ -83,9 +82,9 @@ testPlinkStandardRelatednessMatrixK() {
     rm -f $outfn
     $gemma -bfile $datadir/HLC \
            -gk 2 -o $testname
-    assertEquals 1 $?
-    # assertEquals "427" `wc -l < $outfn`
-    # assertEquals "-358.07" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    assertEquals "427" `wc -l < $outfn`
+    assertEquals "-358.07" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 # Test for https://github.com/genetics-statistics/GEMMA/issues/58
@@ -99,10 +98,10 @@ testPlinkMultivariateLinearMixedModel() {
            -maf 0.1 \
            -c $datadir/HLC_covariates.txt \
            -o $testname
-    assertEquals 1 $?
-    # outfn=output/$testname.assoc.txt
-    # assertEquals "223243" `wc -l < $outfn`
-    # assertEquals "89756559859.06" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
+    assertEquals 0 $?
+    outfn=output/$testname.assoc.txt
+    assertEquals "223243" `wc -l < $outfn`
+    assertEquals "89756559859.06" `perl -nle 'foreach $x (split(/\s+/,$_)) { $sum += sprintf("%.2f",(substr($x,,0,6))) } END { printf "%.2f",$sum }' $outfn`
 }
 
 shunit2=`which shunit2`


### PR DESCRIPTION
- Matrix checks as described in https://github.com/genetics-statistics/GEMMA/issues/72
- introduces -strict switch which will exit on certain conditions
- zero small eigenvalues in EigenDecomp_Zeroed which also checks for negative values
- commented out float versions of functions in lapack.cpp (pre-removal)
- reverted on disabled regression tests (GEMMA shows its previous behaviour now)