### PR TITLE
check GSL_MINOR_VERSION while compiling

### DIFF
--- a/src/mathfunc.cpp
+++ b/src/mathfunc.cpp
@@ -229,7 +229,7 @@ bool isMatrixPositiveDefinite(const gsl_matrix *G) {
   auto G2 = gsl_matrix_alloc(G->size1, G->size2);
   enforce_gsl(gsl_matrix_memcpy(G2,G));
   auto handler = gsl_set_error_handler_off();
-#if GSL_MAJOR_VERSION >= 2
+#if GSL_MAJOR_VERSION >= 2 && GSL_MINOR_VERSION >= 3
   auto s = gsl_linalg_cholesky_decomp1(G2);
 #else
   auto s = gsl_linalg_cholesky_decomp(G2);


### PR DESCRIPTION
Fixes https://github.com/genetics-statistics/GEMMA/issues/84

`gsl_linalg_cholesky_decomp1` has been introduced in GSL 2.3.
The current code expects it  to be introduced in GSL 2.0.

http://git.savannah.gnu.org/cgit/gsl.git
